### PR TITLE
fix: leader should step down when window loses focus

### DIFF
--- a/jetbrains-plugin/src/main/kotlin/com/oneide/services/cluster/Roles.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/oneide/services/cluster/Roles.kt
@@ -125,6 +125,11 @@ class Leader(cluster: ClusterService) : BaseRole(cluster) {
 
     override fun onHeartbeat() {
         super.onHeartbeat()
+        if (!cluster.getIdeConnector().isWindowFocused()) {
+            logger.info("Leader: Window lost focus, downgrading to Follower")
+            cluster.becomeFollower()
+            return
+        }
         if (!cluster.checkIfLeaderIsMe()) {
             logger.info(
                 "Leader: Found another leader or leader file missing, downgrading to Follower"

--- a/jetbrains-plugin/src/test/kotlin/com/oneide/services/cluster/LeaderRoleTest.kt
+++ b/jetbrains-plugin/src/test/kotlin/com/oneide/services/cluster/LeaderRoleTest.kt
@@ -1,0 +1,56 @@
+package com.oneide.services.cluster
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.oneide.OneIde
+import com.oneide.models.Role
+import com.oneide.services.ClusterService
+import org.junit.Test
+import java.nio.file.Path
+
+/**
+ * Tests for Leader role behavior, specifically verifying that
+ * the leader steps down when the IDE window loses focus.
+ *
+ * In a test environment, isWindowFocused() returns false (no real window),
+ * which directly validates the focus-check fix.
+ */
+class LeaderRoleTest : BasePlatformTestCase() {
+
+    private lateinit var oneIdeDir: Path
+    private lateinit var clusterService: ClusterService
+
+    override fun setUp() {
+        super.setUp()
+        oneIdeDir = createTempDir("one-ide-test").toPath()
+        OneIde.oneIdeDir = oneIdeDir
+        clusterService = project.getService(ClusterService::class.java)
+    }
+
+    @Test
+    fun `test leader steps down on heartbeat when window not focused`() {
+        // Force transition to Leader
+        clusterService.becomeLeader()
+        assertEquals("Should be Leader", Role.LEADER, clusterService.getRoleType())
+
+        // Simulate a heartbeat - in test env, window is not focused
+        // so the leader should step down to Follower
+        clusterService.becomeLeader()
+        val leader = Leader(clusterService)
+        leader.onHeartbeat()
+
+        // After heartbeat with unfocused window, should have stepped down
+        assertEquals("Should step down to Follower", Role.FOLLOWER, clusterService.getRoleType())
+    }
+
+    @Test
+    fun `test leader updates heartbeat on user activity`() {
+        clusterService.becomeLeader()
+        val leader = Leader(clusterService)
+
+        // Should not throw - verifies updateLeaderHeartbeat works
+        leader.onUserActivity()
+
+        // Verify heartbeat was written via the service's own cluster directory
+        assertNotNull("Leader info should exist after user activity", clusterService.getLeaderInfo())
+    }
+}

--- a/vscode-extension/src/services/cluster/roles/Leader.ts
+++ b/vscode-extension/src/services/cluster/roles/Leader.ts
@@ -21,7 +21,11 @@ export class Leader extends BaseRole {
 
     async onHeartbeat(): Promise<void> {
         await super.onHeartbeat();
-        // Check if I am still the leader
+        if (!this.cluster.getIdeConnector().isWindowFocused()) {
+            Logger.log('Leader: Window lost focus, downgrading to Follower');
+            await this.cluster.becomeFollower();
+            return;
+        }
         if (!this.cluster.checkIfLeaderIsMe()) {
             Logger.log('Leader: Found another leader or leader file missing, downgrading to Follower');
             await this.cluster.becomeFollower();

--- a/vscode-extension/src/test/services/cluster/roles/Leader.test.ts
+++ b/vscode-extension/src/test/services/cluster/roles/Leader.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { Leader } from '../../../../services/cluster/roles/Leader';
+import { ActionRegistry, RoleType } from '../../../../services/cluster/ActionRegistry';
+
+/**
+ * Minimal mock for ClusterService, providing only what Leader needs.
+ */
+class MockClusterService {
+    public readonly actionRegistry = new ActionRegistry();
+    private _isWindowFocused = true;
+    private _isLeaderMe = true;
+    public becomeFollowerCalled = false;
+    public updateHeartbeatCalled = false;
+
+    setWindowFocused(focused: boolean) {
+        this._isWindowFocused = focused;
+    }
+
+    setLeaderIsMe(isMe: boolean) {
+        this._isLeaderMe = isMe;
+    }
+
+    getIdeConnector() {
+        const focused = this._isWindowFocused;
+        return {
+            isWindowFocused: () => focused
+        };
+    }
+
+    checkIfLeaderIsMe(): boolean {
+        return this._isLeaderMe;
+    }
+
+    async becomeFollower() {
+        this.becomeFollowerCalled = true;
+    }
+
+    updateLeaderHeartbeat() {
+        this.updateHeartbeatCalled = true;
+    }
+
+    reset() {
+        this.becomeFollowerCalled = false;
+        this.updateHeartbeatCalled = false;
+    }
+}
+
+describe('Leader Role', () => {
+    let mockCluster: MockClusterService;
+    let leader: Leader;
+
+    beforeEach(() => {
+        mockCluster = new MockClusterService();
+        leader = new Leader(mockCluster as any);
+    });
+
+    describe('onHeartbeat', () => {
+        it('should step down to follower when window loses focus', async () => {
+            mockCluster.setWindowFocused(false);
+            mockCluster.setLeaderIsMe(true);
+
+            await leader.onHeartbeat();
+
+            expect(mockCluster.becomeFollowerCalled).to.be.true;
+        });
+
+        it('should not step down when window is focused and still leader', async () => {
+            mockCluster.setWindowFocused(true);
+            mockCluster.setLeaderIsMe(true);
+
+            await leader.onHeartbeat();
+
+            expect(mockCluster.becomeFollowerCalled).to.be.false;
+        });
+
+        it('should step down when window is focused but no longer leader', async () => {
+            mockCluster.setWindowFocused(true);
+            mockCluster.setLeaderIsMe(false);
+
+            await leader.onHeartbeat();
+
+            expect(mockCluster.becomeFollowerCalled).to.be.true;
+        });
+
+        it('should not check leader file when window is not focused', async () => {
+            // When window loses focus, becomeFollower should be called
+            // without needing to check checkIfLeaderIsMe
+            mockCluster.setWindowFocused(false);
+            mockCluster.setLeaderIsMe(false);
+
+            await leader.onHeartbeat();
+
+            // becomeFollower should be called exactly once (from focus check, not leader check)
+            expect(mockCluster.becomeFollowerCalled).to.be.true;
+        });
+    });
+
+    describe('init', () => {
+        it('should update leader heartbeat on init', async () => {
+            await leader.init();
+
+            expect(mockCluster.updateHeartbeatCalled).to.be.true;
+        });
+    });
+
+    describe('onUserActivity', () => {
+        it('should update leader heartbeat on user activity', async () => {
+            await leader.onUserActivity();
+
+            expect(mockCluster.updateHeartbeatCalled).to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
### Problem

When IntelliJ IDEA (or any JetBrains IDE) runs an application, it remains permanently locked as the cluster leader even after the user switches focus to another IDE like VS Code. This prevents other IDEs from taking leadership, so edits made in those secondary IDEs never sync back to the cluster.

The root cause is that Leader.onHeartbeat() never checks window focus status — the heartbeat fires every 700ms and keeps the leader's timestamp fresh indefinitely.

### Fix

Added a isWindowFocused() check at the top of Leader.onHeartbeat() in both the JetBrains plugin and VS Code extension. If the window is not focused, the leader immediately steps down to follower, allowing the newly focused IDE to acquire leadership within ~700ms.

### Changes

jetbrains-plugin: Roles.kt — Leader.onHeartbeat() now checks isWindowFocused() before refreshing leadership
vscode-extension: Leader.ts — same focus check added for feature parity
Added unit tests for both plugins

---

Fixes #3