### PR TITLE
feat: Complete Kiro support - add steering rules, update gitignore and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ state.json
 jetbrains-plugin/build/
 jetbrains-plugin/bin/
 
+# Kiro
+.kiro/settings/mcp.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.kiro/steering/project_rules.md
+++ b/.kiro/steering/project_rules.md
@@ -1,0 +1,6 @@
+# Project Rules
+
+- **Cross-Plugin Feature Parity**: When updating the code of any plugin (e.g., JetBrains plugin), always consider if the same update needs to be applied to other plugins (e.g., VS Code extension) to maintain feature parity and consistency.
+- **Service-Based Architecture**: Maintain a consistent service-oriented architecture across both platforms. Core logic should reside in services with identical names and responsibilities (e.g., `ClusterService`, `RuleService`, `ConfigService`).
+- **Shared State & File System**: Use the same file-based coordination mechanism. Shared data must be stored in `~/.one-ide/` with identical file structures and JSON formats.
+- **Testing Requirements**: Core services and logic must have corresponding unit tests in both plugins to ensure consistent behavior across platforms.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Supported AI Tools:
 - Junie (`.junie`)
 - Qodo (`.codiumai.toml`, `.codiumai.yaml`)
 - Qoder (`.qoder`)
+- Kiro (`.kiro/steering`)
 - Antigravity (`.antigravity/rules`)
 
 ## Installation


### PR DESCRIPTION
Completes the Kiro support that was partially added in fa16fa5.

### Changes

- **`.kiro/steering/project_rules.md`**: Added project rules for Kiro (matching the rules in `.claude/rules`, `.cursor/rules`, `.trae/rules`, `.antigravity/rules`)
- **`.gitignore`**: Added `.kiro/settings/mcp.json` to gitignore (user-specific MCP config should not be committed)
- **`README.md`**: Added Kiro (`.kiro/steering`) to the supported AI tools list