### PR TITLE
fix: correct path boundary checking in StateHelper

### DIFF
--- a/jetbrains-plugin/src/main/kotlin/com/oneide/utils/StateHelper.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/oneide/utils/StateHelper.kt
@@ -30,14 +30,14 @@ object StateHelper {
         val rootPathLower = rootPath.normalizePath()
 
         val filePaths = openedFiles
-            .filter { it.normalizePath().startsWith(rootPathLower) }
+            .filter { isInsideRoot(rootPathLower, it.normalizePath()) }
             .map { it.normalizePath() }
             .toMutableList()
 
         var activeFileInRoot: ActiveFile? = null
         if (activeFile != null) {
             val activePathLower = activeFile.filePath.normalizePath()
-            if (activePathLower.startsWith(rootPathLower)) {
+            if (activePathLower.startsWith(rootPathLower) && (activePathLower.length == rootPathLower.length || activePathLower[rootPathLower.length] == java.io.File.separatorChar)) {
                 activeFileInRoot = activeFile.copy(filePath = activePathLower)
             }
         }
@@ -68,7 +68,7 @@ object StateHelper {
 
         return state.editorState.openedFiles.filter { f ->
             val fPath = f.normalizePath()
-            fPath.startsWith(normalizedRootPath)
+            isInsideRoot(normalizedRootPath, fPath)
         }
     }
 
@@ -83,7 +83,7 @@ object StateHelper {
         val normalizedRootPath = rootPath.normalizePath()
         val active = state.editorState.activeFile ?: return null
 
-        if (active.filePath.normalizePath().startsWith(normalizedRootPath)) {
+        if (isInsideRoot(normalizedRootPath, active.filePath.normalizePath())) {
             return active
         }
         return null
@@ -100,7 +100,7 @@ object StateHelper {
         val p1Raw = if (pathOrState1 is State) pathOrState1.root else pathOrState1.toString()
         val p1 = p1Raw.normalizePath()
         val p2 = path2.normalizePath()
-        return p1.startsWith(p2) || p2.startsWith(p1)
+        return isInsideRoot(p1, p2) || isInsideRoot(p2, p1)
     }
 
     /**

--- a/jetbrains-plugin/src/test/kotlin/com/oneide/utils/StateHelperTest.kt
+++ b/jetbrains-plugin/src/test/kotlin/com/oneide/utils/StateHelperTest.kt
@@ -141,6 +141,9 @@ class StateHelperTest : BasePlatformTestCase() {
         assertTrue(StateHelper.hasIntersection("/User/Project", "/User/Project/Sub"))
         assertTrue(StateHelper.hasIntersection("/User/Project/Sub", "/User/Project"))
         assertFalse(StateHelper.hasIntersection("/User/Project", "/User/Other"))
+        // Paths sharing a prefix but in different directories should NOT intersect
+        assertFalse(StateHelper.hasIntersection("/User/easy-api", "/User/easy-api-universal/apilot"))
+        assertFalse(StateHelper.hasIntersection("/User/ProjectA", "/User/ProjectAB"))
 
         val rootPath = "/User/Project"
         val rootPathLower = Paths.get(rootPath).toAbsolutePath().normalize().toString().lowercase()

--- a/vscode-extension/src/services/StateHelper.ts
+++ b/vscode-extension/src/services/StateHelper.ts
@@ -17,13 +17,13 @@ export class StateHelper {
         const rootPathLower = PathUtils.normalizePath(rootPath);
 
         const filePaths: string[] = openedFiles
-            .filter(f => PathUtils.normalizePath(f).startsWith(rootPathLower))
+            .filter(f => StateHelper.isInsideRoot(rootPathLower, PathUtils.normalizePath(f)))
             .map(f => PathUtils.normalizePath(f));
         
         let activeFileInRoot: ActiveFile | undefined = undefined;
         if (activeFile) {
             const activePathLower = PathUtils.normalizePath(activeFile.filePath);
-            if (activePathLower.startsWith(rootPathLower)) {
+            if (activePathLower.startsWith(rootPathLower) && (activePathLower.length === rootPathLower.length || activePathLower[rootPathLower.length] === path.sep)) {
                 activeFileInRoot = {
                     ...activeFile,
                     filePath: activePathLower
@@ -57,7 +57,7 @@ export class StateHelper {
         const p1Raw = typeof pathOrState1 === 'string' ? pathOrState1 : pathOrState1.root;
         const p1 = PathUtils.normalizePath(p1Raw);
         const p2 = PathUtils.normalizePath(path2);
-        return p1.startsWith(p2) || p2.startsWith(p1);
+        return StateHelper.isInsideRoot(p1, p2) || StateHelper.isInsideRoot(p2, p1);
     }
 
     /**
@@ -102,7 +102,7 @@ export class StateHelper {
         return state.editorState.openedFiles.filter(f => {
             try {
                 const fPath = PathUtils.normalizePath(f);
-                return fPath.startsWith(normalizedRootPath);
+                return StateHelper.isInsideRoot(normalizedRootPath, fPath);
             } catch (e) {
                 return false;
             }
@@ -121,7 +121,7 @@ export class StateHelper {
         const active = state.editorState.activeFile;
         if (!active) return undefined;
 
-        if (PathUtils.normalizePath(active.filePath).startsWith(normalizedRootPath)) {
+        if (StateHelper.isInsideRoot(normalizedRootPath, PathUtils.normalizePath(active.filePath))) {
             return active;
         }
         return undefined;

--- a/vscode-extension/src/test/services/StateHelper.test.ts
+++ b/vscode-extension/src/test/services/StateHelper.test.ts
@@ -134,6 +134,9 @@ describe('StateHelper', () => {
             assert.strictEqual(StateHelper.hasIntersection('/User/Project', '/User/Project/Sub'), true);
             assert.strictEqual(StateHelper.hasIntersection('/User/Project/Sub', '/User/Project'), true);
             assert.strictEqual(StateHelper.hasIntersection('/User/Project', '/User/Other'), false);
+            // Paths sharing a prefix but in different directories should NOT intersect
+            assert.strictEqual(StateHelper.hasIntersection('/User/easy-api', '/User/easy-api-universal/apilot'), false);
+            assert.strictEqual(StateHelper.hasIntersection('/User/ProjectA', '/User/ProjectAB'), false);
         });
 
         it('should work with state object', () => {


### PR DESCRIPTION
## Changes

- Replace simple startsWith with proper path boundary check
- Prevent false matches when path names share prefixes (e.g., /foo/bar matching /foo/barbaz)
- Add test cases to verify correct behavior for paths with common prefixes
- Apply fix to both JetBrains and VSCode implementations

This fix ensures that path checking correctly identifies whether a file is inside a root directory by checking for proper path boundaries, not just prefix matching.